### PR TITLE
Fixed DelegateWiki only considering missing pages to exist on items

### DIFF
--- a/WikithisItem.cs
+++ b/WikithisItem.cs
@@ -15,7 +15,7 @@ namespace Wikithis {
 		public override bool PreDrawTooltipLine(Item item, DrawableTooltipLine line, ref int yOffset) {
 			IWiki wiki = Wikithis.Wikis[$"{nameof(Wikithis)}/{nameof(ItemWiki)}"];
 			bool wrong = !wiki.IsValid(item.type);
-			if (wrong && Wikithis.DelegateWikis.TryGetValue(item.ModItem?.Mod.Name ?? "Terraria", out var delegates) && !delegates.pageExists(item, item.type)) {
+			if (wrong && Wikithis.DelegateWikis.TryGetValue(item.ModItem?.Mod.Name ?? "Terraria", out var delegates) && delegates.pageExists(item, item.type)) {
 				wrong = false;
 			}
 


### PR DESCRIPTION
It was changing the value of "wrong" to false if the mod had a DelegateWiki but didn't have a page for the item instead of if the mod had a DelegateWiki and a page for the item